### PR TITLE
Format rate in s/it when rate is < 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+venv
 output.txt
 dist
 build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.4
+
+- Invert rate display to s/it if rate is less than 1
+
 # 0.1.3
 
 - Fix compatibility with python-logstash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tqdm-loggable"
-version = "0.1.3"
+version = "0.1.4"
 description = "TQDM progress bar friendliness for non-interactive terminals and logging output"
 authors = ["Mikko Ohtamaa <mikko@opensourcehacker.com>"]
 license = "MIT"

--- a/tests/slow_rate_test.py
+++ b/tests/slow_rate_test.py
@@ -1,0 +1,9 @@
+import time
+import logging
+from tqdm_loggable.auto import tqdm
+
+logging.basicConfig(level=logging.INFO)
+
+
+for i in tqdm(range(10)):
+    time.sleep(5)

--- a/tqdm_loggable/tqdm_logging.py
+++ b/tqdm_loggable/tqdm_logging.py
@@ -113,7 +113,10 @@ class tqdm_logging(tqdm_auto):
         elapsed_str = tqdm_auto.format_interval(elapsed)
 
         if rate:
-            rate_formatted = f"{rate:,.1f}{unit}/s"
+            if rate > 1:
+                rate_formatted = f"{rate:,.1f}{unit}/s"
+            else:
+                rate_formatted = f"{1/rate:,.1f}s/{unit}"
         else:
             rate_formatted = "-"
 


### PR DESCRIPTION
For slow running iterations it's much more informative to see `rate:120s/it` than `rate:0it/s`