### PR TITLE
Override close method to avoid printing extra newline

### DIFF
--- a/tqdm_loggable/tqdm_logging.py
+++ b/tqdm_loggable/tqdm_logging.py
@@ -154,3 +154,11 @@ class tqdm_logging(tqdm_auto):
 
         self.last_log_message_at = datetime.now()
 
+    def close(self):
+        if self.disable:
+            return
+
+        # Prevent multiple closures
+        self.disable = True
+
+        self.display()


### PR DESCRIPTION
This patch overrides tqdm.close so that it doesn't add the extra newline.

closes #5 