### PR TITLE
Fix Datalore environment detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+# 0.4.1
+- Fix: Restore Datalore stdout-only detection for current runtimes that expose `DATALORE_*` environment variables instead of `AGENT_MANAGER_HOST=datalore` (2026-03-16)
+
 # 0.4
 
-- Fix: Restore Datalore stdout-only detection for current runtimes that expose `DATALORE_*` environment variables instead of `AGENT_MANAGER_HOST=datalore` (2026-03-16)
 - Add: `TQDM_LOGGABLE_FORCE=stdout|logging|auto` environment override for deterministic progress rendering in notebook kernels and batch runners like `jupyter execute` (2026-03-15)
 - Add: tests covering forced stdout and logging selection in `tqdm_loggable.auto` (2026-03-15)
 - Docs: document the override for notebook kernels that should render progress in the calling TTY instead of widget/HTML output (2026-03-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.4
 
+- Fix: Restore Datalore stdout-only detection for current runtimes that expose `DATALORE_*` environment variables instead of `AGENT_MANAGER_HOST=datalore` (2026-03-16)
 - Add: `TQDM_LOGGABLE_FORCE=stdout|logging|auto` environment override for deterministic progress rendering in notebook kernels and batch runners like `jupyter execute` (2026-03-15)
 - Add: tests covering forced stdout and logging selection in `tqdm_loggable.auto` (2026-03-15)
 - Docs: document the override for notebook kernels that should render progress in the calling TTY instead of widget/HTML output (2026-03-15)

--- a/tests/test_tqdm_logging.py
+++ b/tests/test_tqdm_logging.py
@@ -7,6 +7,7 @@ import warnings
 from datetime import timedelta
 
 from tqdm_loggable.tqdm_logging import tqdm_logging, _utc_epoch
+from tqdm_loggable.utils import DATALORE_ENV_VARS, is_stdout_only_session
 
 
 def test_no_deprecation_warnings(caplog):
@@ -80,3 +81,29 @@ def test_invalid_force_mode_is_ignored(monkeypatch):
     auto_module = _reload_auto_module()
 
     assert auto_module.tqdm is not None
+
+
+def test_detects_legacy_datalore_env(monkeypatch):
+    """Ensure older Datalore environments still use stdout-only mode."""
+    monkeypatch.setenv("AGENT_MANAGER_HOST", "datalore")
+
+    assert is_stdout_only_session() is True
+
+
+def test_detects_current_datalore_env(monkeypatch):
+    """Ensure current Datalore environment markers trigger stdout-only mode."""
+    for name in DATALORE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    monkeypatch.setenv("DATALORE_AGENT_MODE", "CONTAINER")
+
+    assert is_stdout_only_session() is True
+
+
+def test_auto_selects_stdout_for_datalore(monkeypatch):
+    """Ensure Datalore notebook runtimes avoid the interactive notebook frontend."""
+    monkeypatch.delenv("TQDM_LOGGABLE_FORCE", raising=False)
+    monkeypatch.setenv("DATALORE_HOME", "/opt/datalore")
+    auto_module = _reload_auto_module()
+
+    assert auto_module.INTERACTIVE_TQDM is False

--- a/tqdm_loggable/utils.py
+++ b/tqdm_loggable/utils.py
@@ -16,6 +16,16 @@ import sys
 #:
 NON_INTERACTIVE_TERM_VALUES = ["dumb", "", None]
 
+#: Stable Datalore environment markers seen in current notebook runtimes.
+#:
+#: `AGENT_MANAGER_HOST=datalore` was used by older environments, but newer
+#: instances expose Datalore-specific variables instead.
+DATALORE_ENV_VARS = [
+    "DATALORE_AGENT_MODE",
+    "DATALORE_HOME",
+    "DATALORE_USER",
+]
+
 
 def get_forced_progress_mode() -> str | None:
     """Get forced progress rendering mode from environment.
@@ -102,4 +112,7 @@ def is_stdout_only_session() -> bool:
     A code report has been privately logged to Datalore support for enquiring about the
     feature disparity between Datalore and Jupyter Notebooks.
     """
-    return os.environ.get("AGENT_MANAGER_HOST", None) == 'datalore'
+    if os.environ.get("AGENT_MANAGER_HOST", None) == "datalore":
+        return True
+
+    return any(os.environ.get(name) for name in DATALORE_ENV_VARS)


### PR DESCRIPTION
## Summary
- keep the legacy `AGENT_MANAGER_HOST=datalore` check for older Datalore runtimes
- detect current Datalore notebooks via stable `DATALORE_*` environment variables
- add regression coverage for both detection paths and the auto selector

## Testing
- env PYTHONPATH=/Users/moo/code/tqdm-loggable pytest -q tests/test_tqdm_logging.py

Closes #7